### PR TITLE
release: AUR PKGBUILD 1.9.5.6 + dockerignore workspace target

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,9 @@
 .git
+src_rust/target
 src_rust/rust_audio_core/target
 src_rust/rust_viz_core/target
 src_rust/rust_launcher/target
+src_rust/rust_tidal_core/target
 build_tmp
 dist
 build_rpmbuild_*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,22 @@ clone restrictions / etc.).
   web content runs without the WebKit sandbox, but the only page
   ever loaded in this WebView is Tidal's login/SSO surface.
 
+### Removed
+
+- **GStreamer is gone.** First release with the V2 native-transport
+  cleanup landed: the playbin field, GStreamer bus-message pump,
+  GStreamer DSP graph, `UsbRawSink` GStreamer element, V1 USB
+  rawlink + V1 PipeWire paths, the `AlsaClock` GObject `SystemClock`
+  subclass, and the LV2 plugin host (panel + ctypes bindings + preset
+  schema) all deleted. Both ALSA(auto) and Auto(Default) outputs now
+  go through the V2 native worker; USB rawlink and ALSA mmap outputs
+  share one `OutputSession` enum behind the same transport.
+  Operationally: the app no longer touches `gst*` libraries at
+  runtime, segment decode is symphonia-only, and there is no GStreamer
+  pipeline to flush on track change. Distro packaging still declares
+  `gstreamer*` runtime deps for safety on this point release; a
+  follow-up will drop them.
+
 ## 1.9.5 beta4 - 2026-05-03
 
 Beta build that follows up the isahc / HTTP/2 swap (beta3) with **parallel multi-segment prefetch**.  beta3 confirmed h2 negotiation and fast `setup_ms`, but a tester still hit ~10 s of stuttering mid-track — Tidal's CDN delivers each HTTP stream at roughly real-time per stream, so the previous 1-deep prefetch could never accumulate more than ~1 segment of head-room in the chunk channel and a 5 s network blip drained the entire pipeline.  This build opens up to 4 segments concurrently on the same h2 connection; nghttp2 multiplexes their bodies and the combined throughput is link-limited (Tidal will give you all 100 Mbps if you ask for 4 streams), so the chunk channel can actually pre-fill to several seconds of compressed FLAC ahead of the decoder.

--- a/aur/hiresti/PKGBUILD
+++ b/aur/hiresti/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=hiresti
-pkgver=1.9.5.5
+pkgver=1.9.5.6
 pkgrel=1
 pkgdesc="High-Res TIDAL player for Linux with bit-perfect playback support"
 arch=('x86_64')
@@ -60,7 +60,7 @@ source=(
   "${pkgname}-${pkgver}.tar.gz::https://github.com/yelanxin/hiresTI/archive/refs/tags/${_tag}.tar.gz"
 )
 sha256sums=(
-  'f101eb8ebe2fa7418a6881a58c2f64a80e14f241e1063f031718ea20ae35cef5'
+  '990af31705c210633736be0a155924ff548f7f9342139acf1cf1d6865153f214'
 )
 
 build() {


### PR DESCRIPTION
## Summary

- Bump `aur/hiresti/PKGBUILD` to 1.9.5.6 with the v1.9.5.6 source tarball sha256 (`990af31705…`).
- Add `src_rust/target` and `src_rust/rust_tidal_core/target` to `.dockerignore`. The workspace-level target dir held 13 GB of debug artifacts from a non-main branch and was getting copied into every `package.sh` Docker image, blowing host disk during `package.sh all`.

Release v1.9.5.6 is already published with all 8 distro artifacts: https://github.com/yelanxin/hiresTI/releases/tag/v1.9.5.6

## Test plan

- [x] Source tarball sha256 matches the v1.9.5.6 tag tarball.
- [x] `package.sh all 1.9.5.6` builds 8/8 targets cleanly with the dockerignore fix.