### PR TITLE
docs: drop GStreamer prerequisite + add Nix install in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 - A high performance Rust audio engine core
 - Bit-perfect playback flow with optional exclusive output controls
 - Built-in USB rawlink driver enables direct USB passthrough, bypassing OS drivers and mixing for purer sound.
-- High-flexibility DSP workspace with reorderable processing, PEQ, convolution, tube/tape color, stereo widening, limiter, resampler, and LV2 plugins
+- High-flexibility DSP workspace with reorderable processing, PEQ, convolution, tube/tape color, stereo widening, limiter, and resampler
 - TIDAL PKCE login (recommended for FLAC / Hi-Res) with legacy OAuth fallback, account-scoped library access
 - TIDAL Max Hi-Res Lossless streaming up to 24-bit / 192kHz
 - Built-in queue drawer, lyrics support, and visualizer modules
@@ -44,8 +44,8 @@ Audio Optimization Guide: [audio-optimization-guide.md](audio-optimization-guide
 
 - Python 3.10+
 - GTK4 + Libadwaita (PyGObject)
-- Rust audio engine core (`rust_audio_core`)
-- GStreamer (audio pipeline runtime via Rust core)
+- Rust audio engine core (`rust_audio_core`) — symphonia decode + native ALSA mmap / USB rawlink output
+- Rust visualizer core (`rust_viz_core`) — FFT + spectrum draw helpers
 - `tidalapi` (TIDAL integration)
 
 ## Audio Engine Note
@@ -60,8 +60,8 @@ Install these system packages first:
 - Python 3.10+
 - GTK4
 - Libadwaita
-- GStreamer core and plugins
 - PyGObject bindings
+- WebKitGTK 6.0 (for the embedded PKCE login flow; optional — paste-URL fallback works without it)
 
 Bundled Python dependencies used by packaging:
 
@@ -109,6 +109,20 @@ sudo dnf install ./hiresti-<version>-1.el9.<arch>.rpm
 ```bash
 sudo pacman -U ./hiresti-<version>-1-<arch>.pkg.tar.zst
 ```
+
+### Nix / NixOS
+
+`hiresTI` ships a flake that exposes `packages.default`, so users on Nix or NixOS can run / install directly from the GitHub repo with no manual dependency setup:
+
+```bash
+# One-shot run (no install)
+nix run github:yelanxin/hiresTI
+
+# Install into your user profile
+nix profile install github:yelanxin/hiresTI
+```
+
+The flake builds the Rust audio + visualizer cores via `rustPlatform.buildRustPackage` and wraps the Python tree with `wrapGAppsHook4`, pulling all GTK4 / WebKit / GStreamer / PipeWire / ALSA dependencies from nixpkgs — no system packages need to be pre-installed.
 
 ### Flatpak
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -67,6 +67,20 @@ sudo dnf install ./hiresti-<版本>-1.fedora.x86_64.rpm
 sudo pacman -U ./hiresti-<版本>-1-x86_64.pkg.tar.zst
 ```
 
+❄️ Nix / NixOS
+
+仓库自带 `flake.nix`，Nix 或 NixOS 用户无需手动安装系统依赖即可直接运行：
+
+```bash
+# 不安装直接试用一次
+nix run github:yelanxin/hiresTI
+
+# 安装到用户 profile
+nix profile install github:yelanxin/hiresTI
+```
+
+flake 通过 `rustPlatform.buildRustPackage` 构建 Rust 音频核心与可视化核心，并用 `wrapGAppsHook4` 包装 Python 树；GTK4 / WebKit / GStreamer / PipeWire / ALSA 等依赖全部从 nixpkgs 拉取。
+
 📦 Flatpak
 从 [Releases Page](../../releases) 页面下载 .flatpak 文件。
 


### PR DESCRIPTION
## Summary

- Remove **GStreamer** from the Tech Stack + Runtime Requirements lists — it's no longer required on the playback path post-1.9.5.6 (the V2 native-transport cleanup that landed via #68 deleted the GStreamer playback path entirely; only \`GstPbutils.Discoverer\` for URI probing remains, and that's pulled transitively from existing GTK deps).
- Drop the "LV2 plugins" line from Highlights — the LV2 plugin host (panel + ctypes bindings + preset schema) was deleted in the same cleanup.
- Add a **Nix / NixOS** install section in both \`README.md\` and \`README_CN.md\`:
  ```
  nix run github:yelanxin/hiresTI
  nix profile install github:yelanxin/hiresTI
  ```

## Test plan

- [x] No code changes; rendered markdown reviewed.