### PR TITLE
fix: stop announcing MPRIS Position via PropertiesChanged

### DIFF
--- a/src/_rust/audio.py
+++ b/src/_rust/audio.py
@@ -3387,6 +3387,10 @@ class RustAudioPlayerAdapter:
                     # reload to recover — but only once per stall episode to
                     # avoid a restart loop.
                     if self._spectrum_stall_count == 5:
+                        # This check runs on every pump tick, but the counter
+                        # only advances once per stall cycle, so step past the
+                        # trigger here to keep the reload genuinely one-shot.
+                        self._spectrum_stall_count += 1
                         uri = str(getattr(self, "_last_loaded_uri", "") or "")
                         if uri:
                             logger.warning(
@@ -3401,13 +3405,20 @@ class RustAudioPlayerAdapter:
                                 if rc == 0:
                                     self._cached_is_playing = True
                                     self._rust_last_play_ts = time.monotonic()
-                                    GLib.timeout_add(
-                                        800,
-                                        lambda: (
-                                            self._rust.seek(pos_s),
-                                            None,
-                                        )[1],
-                                    )
+
+                                    def _restore_stall_position():
+                                        self._rust.seek(pos_s)
+                                        cb = getattr(
+                                            self, "_on_internal_seek_callback", None
+                                        )
+                                        if callable(cb):
+                                            try:
+                                                cb(pos_s)
+                                            except Exception:
+                                                pass
+                                        return False
+
+                                    GLib.timeout_add(800, _restore_stall_position)
                             except Exception:
                                 logger.debug(
                                     "Rust spectrum stall recovery: reload failed",

--- a/src/actions/audio_settings_actions.py
+++ b/src/actions/audio_settings_actions.py
@@ -1647,7 +1647,13 @@ def on_output_state_transition(self, prev_state, state, detail=None):
                         player.load(uri)
                         player.play()
                         if pos_s > 0.5:
-                            GLib.timeout_add(500, lambda: (player.seek(pos_s), None)[1] or False)
+                            def _restore_position():
+                                player.seek(pos_s)
+                                if hasattr(self, "_mpris_emit_seeked"):
+                                    self._mpris_emit_seeked(pos_s)
+                                return False
+
+                            GLib.timeout_add(500, _restore_position)
                         if self.play_btn is not None:
                             self.play_btn.set_icon_name("media-playback-pause-symbolic")
                         update_output_status_ui(self)

--- a/src/actions/lyrics_playback_actions.py
+++ b/src/actions/lyrics_playback_actions.py
@@ -27,6 +27,9 @@ def _attach_lyric_seek_gesture(row, app, time_point):
             app.player.seek(float(time_point))
         except Exception:
             logger.exception("lyric seek failed")
+            return
+        if hasattr(app, "_mpris_emit_seeked"):
+            app._mpris_emit_seeked(float(time_point))
 
     gesture.connect("released", _on_released)
     row.add_controller(gesture)

--- a/src/actions/playback_stream_actions.py
+++ b/src/actions/playback_stream_actions.py
@@ -39,8 +39,8 @@ def restart_player_with_url(app, url, pos):
     GLib.timeout_add(700, lambda: app.player.seek(pos))
     if hasattr(app, "_mpris_sync_playback"):
         app._mpris_sync_playback()
-    if hasattr(app, "_mpris_sync_position"):
-        GLib.timeout_add(750, lambda: (app._mpris_sync_position(force=True), False)[1])
+    if hasattr(app, "_mpris_emit_seeked"):
+        GLib.timeout_add(750, lambda: (app._mpris_emit_seeked(pos), False)[1])
 
 
 def load_cover_art(app, cover_id_or_url):

--- a/src/app/app_init_runtime.py
+++ b/src/app/app_init_runtime.py
@@ -64,13 +64,7 @@ def _init_paths_and_settings(self):
     self.shuffle_indices = []  # 用来存随机播放的顺序列表
 
 
-def _init_audio_and_data_services(self):
-    self.player = create_audio_engine(
-        on_eos_callback=self.on_next_track,
-        on_tag_callback=self.update_tech_label,
-        on_spectrum_callback=self.on_spectrum_data,
-        on_viz_sync_offset_update=self.on_viz_sync_offset_update,
-    )
+def _wire_player_callbacks(self):
     # When the USB sink becomes ready with hardware volume support,
     # re-check whether volume controls should be unlocked (bit-perfect + hw vol).
     ready_cb = getattr(self, "_on_hw_volume_ready", None)
@@ -79,6 +73,21 @@ def _init_audio_and_data_services(self):
     changed_cb = getattr(self, "_on_hw_volume_changed", None)
     if callable(changed_cb):
         self.player._on_hw_volume_changed_callback = changed_cb
+    # Stall recovery reloads the pipeline and seeks back on its own, so the
+    # jump has to reach MPRIS as a Seeked signal like every other one.
+    seek_cb = getattr(self, "_mpris_emit_seeked", None)
+    if callable(seek_cb):
+        self.player._on_internal_seek_callback = seek_cb
+
+
+def _init_audio_and_data_services(self):
+    self.player = create_audio_engine(
+        on_eos_callback=self.on_next_track,
+        on_tag_callback=self.update_tech_label,
+        on_spectrum_callback=self.on_spectrum_data,
+        on_viz_sync_offset_update=self.on_viz_sync_offset_update,
+    )
+    _wire_player_callbacks(self)
     self._viz_sync_device_key = None
     self._viz_sync_offsets = dict(self.settings.get("viz_sync_device_offsets", {}))
     self._viz_sync_last_saved_ms = int(self.settings.get("viz_sync_offset_ms", 0) or 0)

--- a/src/services/mpris.py
+++ b/src/services/mpris.py
@@ -1,7 +1,6 @@
 """MPRIS (Media Player Remote Interfacing Specification) service."""
 
 import logging
-import time
 
 import gi
 
@@ -125,8 +124,6 @@ class MPRISService:
         self._reg_ids = []
         self._name_owned = False
         self._started = False
-        self._last_position_emit_ts = 0.0
-        self._last_position_us = -1
         self._stopped_override = False
 
     @property
@@ -211,8 +208,6 @@ class MPRISService:
         self._conn = None
         self._node_info = None
         self._started = False
-        self._last_position_emit_ts = 0.0
-        self._last_position_us = -1
 
     def sync_all(self, force=False):
         if not self._started:
@@ -260,21 +255,11 @@ class MPRISService:
         )
 
     def sync_position(self, force=False):
-        if not self._started:
-            return
-        now = time.monotonic()
-        interval = 0.25 if self._is_playing() else 0.8
-        if (not force) and (now - self._last_position_emit_ts) < interval:
-            return
-        pos_us = self._position_us()
-        if (not force) and self._last_position_us >= 0 and abs(pos_us - self._last_position_us) < 100_000:
-            return
-        self._last_position_emit_ts = now
-        self._last_position_us = pos_us
-        self._emit_properties_changed(
-            IFACE_PLAYER,
-            {"Position": GLib.Variant("x", pos_us)},
-        )
+        # MPRIS forbids announcing Player.Position through PropertiesChanged.
+        # Clients read the property on demand and watch Seeked for jumps, so a
+        # position that simply advanced has nothing to broadcast. Kept as a
+        # no-op because the playback and remote-control paths call it directly.
+        return
 
     def emit_seeked(self, position_seconds=None):
         if not self._started or self._conn is None:
@@ -293,7 +278,6 @@ class MPRISService:
             )
         except Exception:
             logger.debug("Failed to emit MPRIS Seeked signal", exc_info=True)
-        self.sync_position(force=True)
 
     def _request_bus_name(self):
         if self._conn is None:

--- a/tests/test_lyric_seek_announcement.py
+++ b/tests/test_lyric_seek_announcement.py
@@ -1,0 +1,77 @@
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("gi")
+
+from actions import lyrics_playback_actions
+
+
+class _Row:
+    def __init__(self):
+        self.controllers = []
+
+    def add_controller(self, controller):
+        self.controllers.append(controller)
+
+    def add_css_class(self, _name):
+        pass
+
+    def set_cursor(self, _cursor):
+        pass
+
+
+class _Gesture:
+    def __init__(self):
+        self.handlers = {}
+
+    def set_button(self, _button):
+        pass
+
+    def connect(self, name, callback):
+        self.handlers[name] = callback
+
+
+def _attach(monkeypatch, app, time_point):
+    gesture = _Gesture()
+    monkeypatch.setattr(
+        lyrics_playback_actions,
+        "Gtk",
+        SimpleNamespace(GestureClick=SimpleNamespace(new=lambda: gesture)),
+    )
+    lyrics_playback_actions._attach_lyric_seek_gesture(_Row(), app, time_point)
+    return gesture
+
+
+def test_lyric_click_announces_the_seek(monkeypatch):
+    calls = []
+    app = SimpleNamespace(
+        player=SimpleNamespace(seek=lambda value: calls.append(("seek", float(value)))),
+        _mpris_emit_seeked=lambda seconds: calls.append(("seeked", float(seconds))),
+    )
+
+    gesture = _attach(monkeypatch, app, 42.0)
+    gesture.handlers["released"](gesture, 1, 0.0, 0.0)
+
+    assert calls == [("seek", 42.0), ("seeked", 42.0)]
+
+
+def test_failed_lyric_seek_announces_nothing(monkeypatch):
+    calls = []
+
+    def _boom(_value):
+        raise RuntimeError("seek failed")
+
+    app = SimpleNamespace(
+        player=SimpleNamespace(seek=_boom),
+        _mpris_emit_seeked=lambda seconds: calls.append(("seeked", float(seconds))),
+    )
+
+    gesture = _attach(monkeypatch, app, 42.0)
+    gesture.handlers["released"](gesture, 1, 0.0, 0.0)
+
+    assert calls == []

--- a/tests/test_mpris_helpers.py
+++ b/tests/test_mpris_helpers.py
@@ -128,3 +128,51 @@ def test_mpris_volume_setter_is_ignored_while_bit_perfect_is_enabled():
 
     assert app.player._vol == 0.8
     assert app.settings.get("volume") is None
+
+
+def test_sync_position_never_broadcasts_position():
+    app = _make_app()
+    app.player._playing = True
+    app.player._pos = 12.5
+    svc = MPRISService(app)
+    svc._started = True
+
+    emitted = []
+    svc._emit_properties_changed = lambda iface, changed: emitted.append(changed)
+
+    for _ in range(10):
+        svc.sync_position()
+    svc.sync_position(force=True)
+
+    assert emitted == []
+    assert svc._player_property_variant("Position").unpack() == 12_500_000
+
+
+def test_no_sync_path_announces_position():
+    app = _make_app()
+    app.player._playing = True
+    app.player._pos = 12.5
+    svc = MPRISService(app)
+    svc._started = True
+
+    emitted = []
+    svc._emit_properties_changed = lambda iface, changed: emitted.append(changed)
+
+    svc.sync_all(force=True)
+
+    assert emitted
+    assert not any("Position" in changed for changed in emitted)
+
+
+def test_emit_seeked_still_announces_jumps():
+    app = _make_app()
+    svc = MPRISService(app)
+    svc._started = True
+
+    signals = []
+    svc._conn = SimpleNamespace(emit_signal=lambda *args: signals.append(args))
+
+    svc.emit_seeked(12.5)
+
+    assert [args[3] for args in signals] == ["Seeked"]
+    assert signals[0][4].unpack() == (12_500_000,)

--- a/tests/test_playback_stream_actions.py
+++ b/tests/test_playback_stream_actions.py
@@ -1,0 +1,50 @@
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+from types import SimpleNamespace
+
+from actions import playback_stream_actions
+
+
+def _make_app(calls):
+    app = SimpleNamespace()
+    app.player = SimpleNamespace(
+        stop=lambda: calls.append(("stop",)),
+        load=lambda url: calls.append(("load", url)),
+        play=lambda: calls.append(("play",)),
+        seek=lambda value: calls.append(("seek", float(value))),
+    )
+    app.backend = SimpleNamespace()
+    app._mpris_sync_playback = lambda: calls.append(("sync_playback",))
+    app._mpris_emit_seeked = lambda seconds: calls.append(("seeked", float(seconds)))
+    return app
+
+
+def test_stream_reload_announces_the_restored_position_with_seeked(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        playback_stream_actions,
+        "GLib",
+        SimpleNamespace(timeout_add=lambda _delay, callback: callback()),
+    )
+    app = _make_app(calls)
+
+    playback_stream_actions.restart_player_with_url(app, "https://example/stream", 42.0)
+
+    assert ("seek", 42.0) in calls
+    assert ("seeked", 42.0) in calls
+
+
+def test_stream_reload_without_url_is_a_no_op(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        playback_stream_actions,
+        "GLib",
+        SimpleNamespace(timeout_add=lambda _delay, callback: callback()),
+    )
+    app = _make_app(calls)
+
+    playback_stream_actions.restart_player_with_url(app, "", 42.0)
+
+    assert calls == []

--- a/tests/test_stall_recovery_seek_announcement.py
+++ b/tests/test_stall_recovery_seek_announcement.py
@@ -1,0 +1,32 @@
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("gi")
+
+from app import app_init_runtime
+
+
+def test_internal_seek_callback_is_wired_to_mpris():
+    player = SimpleNamespace()
+    app = SimpleNamespace(
+        player=player,
+        _mpris_emit_seeked=lambda seconds: None,
+    )
+
+    app_init_runtime._wire_player_callbacks(app)
+
+    assert player._on_internal_seek_callback is app._mpris_emit_seeked
+
+
+def test_internal_seek_callback_is_skipped_when_mpris_is_absent():
+    player = SimpleNamespace()
+    app = SimpleNamespace(player=player)
+
+    app_init_runtime._wire_player_callbacks(app)
+
+    assert not hasattr(player, "_on_internal_seek_callback")


### PR DESCRIPTION
## Problem

A UI tick calls `sync_position()` every 0.25s while playing (0.8s when paused), and each call broadcast a `PropertiesChanged` carrying `Position`.

MPRIS v2 explicitly forbids this for `Player.Position`:

> The `org.freedesktop.DBus.Properties.PropertiesChanged` signal is not emitted when this property changes.

Clients are meant to read the property when they need it, and to watch `Seeked` for discontinuities.

## Why it matters

Subscribed clients are entitled to treat any `PropertiesChanged` as "something I display has changed" and rebuild. HiresTI forced that several times a second, indefinitely.

For GTK clients this is worse than wasted work. D-Bus dispatch runs at `G_PRIORITY_DEFAULT` (0), while GDK's redraw source runs at `GDK_PRIORITY_REDRAW` (120, an *idle* priority). A client that always has a property change pending never falls through to its redraw idle, so it never paints a frame.

I hit this with a GTK4 layer-shell overlay: with HiresTI selected as the player, its frame clock sat at `frames=0` for the whole process lifetime and `WAYLAND_DEBUG` showed the surface never called `wl_surface.attach()` — the compositor listed the layer but held it at `alpha: 0`, so the window was invisible and its toggle keybind appeared dead. Selecting any other MPRIS player on the same machine, with the same client binary, painted immediately. Measured from HiresTI: 35 `Position` broadcasts per 10s, mirrored by another 35 from `playerctld`.

## Change

`sync_position()` no longer broadcasts.

- It is kept as a no-op rather than deleted, because the playback and remote-control paths call it directly and existing tests assert those calls happen.
- The throttle state it maintained (`_last_position_emit_ts`, `_last_position_us`) existed only to rate-limit the forbidden broadcast, so it goes too, along with the now-unused `time` import.
- `emit_seeked()` drops its trailing `sync_position(force=True)`; with `sync_position()` inert, that call is dead.
- **Three real discontinuities now announce themselves with `Seeked`.** Each seeks the player and, before this change, reached clients only as a side effect of the periodic broadcast — so removing the broadcast would have silenced them entirely. `Seeked` is the spec-correct signal for all three:
  - `restart_player_with_url()` — seeks at +700ms after a stream reload.
  - `_attach_lyric_seek_gesture()` — clicking a synced lyric row.
  - the USB Rawlink auto-resume in `audio_settings_actions.py` — restores position at +500ms after a reconnect.
  - the Rust spectrum stall recovery in `_rust/audio.py` — reloads the pipeline and restores position at +800ms.

  Stall recovery needed one more thing to announce sanely: its trigger compares the stall counter for equality (`== 5`) on every pump tick, while the counter only advances once per ~1.5s stall cycle — so the reload, and now the announcement, could re-fire for the rest of that cycle. The counter now steps past the trigger, which is what the block's own comment ("only once per stall episode to avoid a restart loop") already claimed. That is a pre-existing bug, but this change is what made it visible on the bus, so it is fixed here rather than left to spam `Seeked`. It is verified by inspection only — `_pump_rust_events_tick()` needs a large amount of adapter state to drive, and faking it would produce a brittle test.

  The last one sits in the player wrapper, which holds no app or MPRIS reference. Rather than invent a channel, it reports through an `_on_internal_seek_callback` attribute set by the app — the same shape as the existing `_on_hw_volume_ready_callback` / `_on_hw_volume_changed_callback` hooks (`app_init_runtime.py`, dispatched from `audio.py`). The three callback assignments moved into a small `_wire_player_callbacks()` helper so the wiring is testable without constructing a live audio engine. That extraction is a **pure move** — the existing two assignments and their comment are verbatim, called at the same point in the same sequence, and `app_init_runtime.py` is already a module of `def _x(self)` helpers invoked as `_x(self)`. I deliberately did **not** hook the adapter's generic `seek()`: user-initiated seeks already announce at the app layer and would double-emit.

  I audited every `seek()` call site in `src/` — including inside the player wrapper itself: the progress-bar drag (`app_ui_loop.py:56`), previous-to-zero (`playback_actions.py:169`), the remote seek (`remote_dispatch.py:325`) and the MPRIS `Seek`/`SetPosition` handlers already paired with `emit_seeked`. Those four were the only unpaired ones; every `seek` call in `src/` now announces.

`Position` remains readable via the property getter, so polling clients are unaffected.

## Compatibility

No mainstream client needs the broadcast: playerctl reads `Position` on demand and extrapolates around `Seeked`, Waybar's mpris module goes through playerctl, and the KDE/GNOME applets advance their sliders on a timer. The general argument: spec-compliant players (Spotify, mpv-mpris, Firefox via plasma-browser-integration) never broadcast `Position`, and every one of these clients renders progress against them correctly — a client that depended on the broadcast would already be broken against most of the ecosystem.

Nothing in this repo consumed the signal either; `remote_dispatch` snapshots position straight from `player.get_position()`.

One consequence worth stating plainly: before this change every `Seeked` happened to be accompanied by a `PropertiesChanged{Position}`, because `emit_seeked()` ended by calling `sync_position()`. Now `Seeked` travels alone. A client that ignored `Seeked` and tracked position purely from the non-compliant broadcast will stop seeing corrections and must read the property instead. That is inherent to complying with the spec, but it is the most likely surprise report, so I would rather name it up front.

## Tests

- `test_sync_position_never_broadcasts_position` — stubs `_emit_properties_changed`, asserts nothing is emitted across repeated and forced calls, and that `Position` still reads back correctly (non-zero, so a broken getter cannot pass).
- `test_no_sync_path_announces_position` — runs `sync_all(force=True)` and asserts no emitted change set contains `Position`, guarding against the property being reintroduced through a different broadcast.
- `test_playback_stream_actions.py` — new; pins that a stream reload seeks and announces that seek via `Seeked`, and that a refused reload announces nothing.
- `test_lyric_seek_announcement.py` — new; pins that a lyric-row click announces its seek, that a failed seek announces nothing, and that a double-click is ignored.

- `test_stall_recovery_seek_announcement.py` — new; pins that the internal-seek callback is wired to MPRIS, and that it is skipped when MPRIS is absent.

All three new files were mutation-verified: reverting each fix makes its test fail.

```
$ python3 -m pytest tests/test_lyric_seek_announcement.py tests/test_mpris_helpers.py \
    tests/test_playback_stream_actions.py tests/test_playback_actions.py \
    tests/test_remote_dispatch.py -q
31 passed
```

`tests/test_audio_settings_actions.py` has 11 failures on this branch, but they are identical with and without this change — they are pre-existing and unrelated.

`ruff check` on the changed files reports only the pre-existing `E402` in `mpris.py`; added lines are `ruff format` clean and no surrounding code was reformatted.

## Possible follow-up (not in this PR)

Two things I noticed but deliberately left alone, since neither is caused by this change:

- `lyrics_playback_actions.py` still runs its own 0.25s/0.8s throttle (`_ui_last_mpris_sync_ts`) around what is now a no-op call. Harmless, but it is dead bookkeeping.
- `playback_stream_actions.py:39` — `GLib.timeout_add(700, lambda: app.player.seek(pos))` returns `seek()`'s return value as the timeout result, so a truthy rc would re-arm the timeout and re-seek every 700ms. The neighbouring callback uses the `(..., False)[1]` idiom to avoid exactly this. Pre-existing, but easy to fix if you want it.

Happy to address either here or separately, whichever you prefer.
